### PR TITLE
Support config nocache

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -271,6 +271,7 @@ function remote(url, options = {}) {
     method,
     cacheDB,
     windowProxy = { document: { html: document.documentElement, body: document.body, head: document.head } },
+    nocache=true
   } = options;
   let { scopeName } = options;
   const __remoteModuleWebpack__ = checkRemoteModuleWebpack(windowProxy.context);
@@ -297,7 +298,7 @@ function remote(url, options = {}) {
         const manifest = await requireManifest(url, {
           timeout,
           global: window,
-          nocache: true,
+          nocache: nocache,
           cacheDB,
           sync,
           cached,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -111,6 +111,7 @@ interface RemoteOptions {
       head: HTMLElement
     }
   },
+  nocache?: boolean,
   isCommonModule?: boolean,
   useEsModuleDefault?: boolean,
   meta?: Record<string, any>


### PR DESCRIPTION
When using the 'remote' method to load remote libraries, the intention is to optionally configure browser caching capability. Consequently, an 'nocache' configuration is appended to the remote method's parameters with a default setting of true, ensuring this integration doesn't interfere with regular usage patterns.